### PR TITLE
modify latitude and longitude in the front

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -135,10 +135,7 @@ def update_doctor(doctor_id):
 @api.route('/medical_centers', methods=['GET'])
 def get_centers():
     centers = MedicalCenter.query.all()
-    return jsonify([{
-        'id': c.id, 'name': c.name, 'address': c.address,
-        'country': c.country, 'city': c.city, 'phone': c.phone, 'email': c.email
-    } for c in centers])
+    return jsonify([center.serialize() for center in centers])  # Usar serialize para incluir todos los campos
 
 # Agregar un nuevo centro médico
 @api.route('/medical_centers', methods=['POST'])

--- a/src/front/js/pages/MedicalCenters.js
+++ b/src/front/js/pages/MedicalCenters.js
@@ -90,19 +90,31 @@ function MedicalCenters() {
     setEditingMedicalCenter(center);
     setMedicalCenterFormData({
       ...center,
-      latitude: center.latitude || "",  // Asegúrate de incluir latitud
-      longitude: center.longitude || ""  // Asegúrate de incluir longitud
+      latitude: center.latitude || "",
+      longitude: center.longitude || "",
     });
+  
     if (center.latitude && center.longitude) {
       setCenter({ lat: center.latitude, lng: center.longitude });
       setMarkerPosition({ lat: center.latitude, lng: center.longitude });
     } else if (center.address) {
+      // Si no hay latitud/longitud, intentar geolocalizar la dirección
       const geocoder = new window.google.maps.Geocoder();
       geocoder.geocode({ address: center.address }, (results, status) => {
         if (status === "OK" && results[0]) {
           const location = results[0].geometry.location;
-          setCenter({ lat: location.lat(), lng: location.lng() });
-          setMarkerPosition({ lat: location.lat(), lng: location.lng() });
+          const lat = location.lat();
+          const lng = location.lng();
+          setCenter({ lat, lng });
+          setMarkerPosition({ lat, lng });
+  
+          if (!center.latitude || !center.longitude) {
+            setMedicalCenterFormData((prevData) => ({
+              ...prevData,
+              latitude: lat,
+              longitude: lng,
+            }));
+          }
         }
       });
     }
@@ -307,8 +319,8 @@ function MedicalCenters() {
           <td>{center.city}</td>
           <td>{center.phone}</td>
           <td>{center.email}</td>
-          <td>{center.latitude}</td>
-          <td>{center.longitude}</td>
+          <td>{center.latitude || "N/A"}</td>
+          <td>{center.longitude || "N/A"}</td>
           <td>
             <button
               className="btn btn-primary btn-sm me-2"

--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -26,8 +26,8 @@ const getState = ({ getStore, getActions, setStore }) => {
                 city: "",
                 phone: "",
                 email: "",
-                latitude: "",  // Nuevo campo
-                longitude: ""  // Nuevo campo
+                latitude: "", 
+                longitude: ""
               },
             editingMedicalCenter: null,
             medicalCenterError: null,


### PR DESCRIPTION
### Descripción
Agregué la funcionalidad de Google Maps Autocomplete al componente MedicalCenters.js para permitir la búsqueda de direcciones y la captura automática de latitud y longitud. También corregí el problema de la persistencia de latitud/longitud al editar y aseguré que se muestren en la tabla.

### Cambios realizados
- Modifiqué MedicalCenters.js para persistir latitud/longitud al editar.
- Actualicé el endpoint GET /medical_centers en routes.py para incluir latitud/longitud.
- Agregué valores por defecto en la tabla para evitar errores.

### Pruebas
- Probé agregar un nuevo centro médico y verificar que latitud/longitud se muestren en la tabla.
- Probé editar un centro médico existente y confirmé que los valores de latitud/longitud persisten.
